### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -31,7 +31,7 @@ jobs:
         run: npm run test:ci
         
       - name: Publish to DockerHub
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           BASE_URL: /ohjaajarekisteri
         with:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore